### PR TITLE
Updated setup instructions README.md with a Python header file note

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -49,6 +49,11 @@ NOTE: If you run into trouble with gevent, you can safely comment it out of
 the requirements.txt file.  It is not needed for local development.  To comment
 it out, just add a hash "#" to the beginning of the line for `gevent`.
 
+NOTE: If you have trouble with `pip install -r requirements.txt`, you may need to
+install the Python development libraries (for Python.h). The Windows installation has them by default,
+but some UNIX-based systems with a pre-installed Python may not. On such systems, you may
+need to run `sudo apt-get install python-dev` or download a fresh installer from python.org.
+
 To run the development server:
 
     src/manage.py runserver


### PR DESCRIPTION
Some systems fail on downloading the dependent libraries because they can't be built without the Python C header files. Added a note explaining how to get them.

Error message before fix (encountered on Ubuntu Linux 12.04 from a fresh-ish install):
Installing collected packages: hashlib, httpagentparser, pyyaml, django-appconf
  Running setup.py install for hashlib
    building '_sha' extension
    gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c Modules/shamodule.c -o build/temp.linux-x86_64-2.7/Modules/shamodule.o
    Modules/shamodule.c:18:20: fatal error: Python.h: No such file or directory
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    Complete output from command /home/someuser/Dev/shareabouts/env/bin/python -c "import setuptools;__file__='/home/someuser/Dev/shareabouts/env/build/hashlib/setup.py';exec(compile(open(**file**).read().replace('\r\n', '\n'), **file**, 'exec'))" install --record /tmp/pip-5Fjiaw-record/install-record.txt --single-version-externally-managed --install-headers /home/someuser/Dev/shareabouts/env/include/site/
