### PR TITLE
Show location type on place detail

### DIFF
--- a/src/sa_web/jstemplates/place-detail.html
+++ b/src/sa_web/jstemplates/place-detail.html
@@ -13,7 +13,7 @@
           <span class="place-submission-details">
             {{#_}}<strong class="point-submitter">
               {{ submitter_name }}
-            </strong> added this {{ location_type }}
+            </strong> added this {{ place_type_label }}
             {{#region}}
               in {{ region }}
             {{/region}}{{/_}}

--- a/src/sa_web/static/js/views/place-detail-view.js
+++ b/src/sa_web/static/js/views/place-detail-view.js
@@ -22,8 +22,13 @@ var Shareabouts = Shareabouts || {};
       var self = this,
           items = S.TemplateHelpers.getItemsFromModel(self.options.placeConfig.items,
             this.model, ['submitter_name', 'name', 'location_type']),
-
+            location_type = this.model.get('location_type'),
+            placeType = this.options.placeTypes[location_type],
+          
+          // TODO : a better default than 'point'?
+          label = placeType ? (placeType.label || location_type) : 'point',
           data = _.extend({
+            place_type_label: label,
             permalink: window.location.toString(),
             pretty_created_datetime: function() {
               return S.Util.getPrettyDateTime(this.created_datetime,


### PR DESCRIPTION
Improving on #5

I'm sorry; I was working from an old commit of shareabouts where there was no `label` on the `location_type` yet. I'll admit I was a bit confused for a second there! I think I understand now.

Is this better? I wasn't quite sure what to do as a fallback if there's no `placeType` defined for the `location_type`, probably there's something better to do than just returning `'point'`.
