### PR TITLE
Fixed broken link to custom.css file in documentation. 

### DIFF
--- a/doc/CUSTOM_THEME.md
+++ b/doc/CUSTOM_THEME.md
@@ -9,4 +9,4 @@ For changing form text, see [the CONFIG documentation](CONFIG.md)
 CSS
 -----
 
-It's simple to customize the Shareabouts Web front-end application to coordinate with your organization's brand guidelines. The [custom.css](../src/sa_web/static/css/custom.css) file contains CSS rules that can be edited to override Shareabouts' default styles. Simply uncomment and edit the example declarations. While more advanced layout techniques are possible within this file, only the basic selectors required to change colors, fonts, shadows, and such are included.
+It's simple to customize the Shareabouts Web front-end application to coordinate with your organization's brand guidelines. The [custom.css](../src/flavors/default/static/css/custom.css) file contains CSS rules that can be edited to override Shareabouts' default styles. Simply uncomment and edit the example declarations. While more advanced layout techniques are possible within this file, only the basic selectors required to change colors, fonts, shadows, and such are included.


### PR DESCRIPTION
Updated link to custom.css file which is now in the flavor's folder. The old link was to this [location](https://github.com/openplans/shareabouts/tree/master/src/sa_web/static/css).
