### PR TITLE
Update leaflet libraries

### DIFF
--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -47,7 +47,7 @@
 
   <link rel="profile" href="http://gmpg.org/xfn/11" />
 
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
   <!--[if lte IE 8]>
       <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.ie.css" />
   <![endif]-->
@@ -127,7 +127,7 @@
   <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="{{ STATIC_URL }}libs/jquery-1.10.2.js"><\/script>')</script><!-- FIXME: Maybe this should be pulled into the repo as a git submodule-->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.6.4/leaflet.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 
   {% if settings.DEBUG %}
   <script src="{{STATIC_URL}}libs/underscore.js"></script>


### PR DESCRIPTION
I was having issues where I was unable to select a Place on the map when testing with a Verizon LG G3 Android smartphone. It seems that Leaflet adds an invisible layer over the entire map, and it was interfering with a tap on a Place. Updating this library fixes that bug.

Hopefully this helps somebody.