### PR TITLE
Fix make api root

### DIFF
--- a/src/sa_web/tests.py
+++ b/src/sa_web/tests.py
@@ -6,6 +6,8 @@ Replace this with more appropriate tests for your application.
 """
 
 from unittest import TestCase
+from django.conf import settings
+import views
 
 
 class SimpleTest(TestCase):
@@ -14,3 +16,17 @@ class SimpleTest(TestCase):
         Tests that 1 + 1 always equals 2.
         """
         self.assertEqual(1 + 1, 2)
+
+class ViewsModules(TestCase):
+    def test_make_api_root(self):
+        withoutHTTP = 'api.shareabouts.org/api/v2/'
+        withHTTP = 'http://api.shareabouts.org/api/v2/'
+        withHTTPS = 'https://api.shareabouts.org/api/v2/'
+        httpResult = '/'
+        settingsResult = 'http://api.shareabouts.org/api/v2'
+        self.assertEqual(views.make_api_root(withoutHTTP),httpResult)
+        self.assertEqual(views.make_api_root(withHTTP),httpResult)
+        self.assertEqual(views.make_api_root(withHTTPS),httpResult)
+
+        settings.SHAREABOUTS['API_ROOT'] = settingsResult
+        self.assertEqual(views.make_api_root('asd;lkfj023jf32nf930f2010f'),settingsResult)

--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -3,6 +3,7 @@ import yaml
 import ujson as json
 import logging
 import os
+import re
 import time
 import hashlib
 import httpagentparser
@@ -24,7 +25,11 @@ log = logging.getLogger(__name__)
 
 
 def make_api_root(dataset_root):
-    components = dataset_root.split('/')
+    # allow for non-dynamic override
+    if settings.SHAREABOUTS['API_ROOT']:
+        return settings.SHAREABOUTS['API_ROOT']
+    # remove http headers before / split
+    components = re.sub(r"http(s)*://","",dataset_root).split('/')
     if dataset_root.endswith('/'):
         return '/'.join(components[:-4]) + '/'
     else:

--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 
 def make_api_root(dataset_root):
     # allow for non-dynamic override
-    if settings.SHAREABOUTS['API_ROOT']:
+    if 'API_ROOT' in settings.SHAREABOUTS:
         return settings.SHAREABOUTS['API_ROOT']
     # remove http headers before / split
     components = re.sub(r"http(s)*://","",dataset_root).split('/')


### PR DESCRIPTION
While working on my project mobility map, I came across this problem in your source code. I preferred a simpler solution in my code, but when sourcing upstream I wanted to provide a test as well as some way to dynamically handle http headers in the make_api_root function.

But basically, the problem is that make_api_root, when fed a url that contains an http header, will accidentally only return "http:/" at times due to the array accessing (components[:-4] and components[:-3]). This doesn't work... at all... so I have the function removing any http headers that might pop up.
