### PR TITLE
python 3 compatibility updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # https://github.com/travis-ci/travis-ci/wiki/.travis.yml-options
 
 python:
-  - "2.6"
   - "2.7"
+  - "3.5"
 
 # This is redundant, but explicit,, since 'sudo' is disabled by default to
 # make use of Travis CI's container technology.

--- a/src/flavors/defaultflavor/config.yml
+++ b/src/flavors/defaultflavor/config.yml
@@ -34,6 +34,7 @@ map:
     zoom: 14
     minZoom: 10
     maxZoom: 17
+    scrollWheelZoom: false
   layers:
     # Raster Tile Layers
     # ==================
@@ -172,7 +173,7 @@ activity:
 place:
   adding_supported:
     from: '2017-03-07 00:00 -0500'   # Daylight savings begins mid-March
-    until: '2017-04-07 00:00 -0400'  # and ends mid-October.
+    until: '2021-04-07 00:00 -0400'  # and ends mid-October.
   add_button_label: _(Add a Place)
   # Labels for the buttons that toggle the map and list views
   show_list_button_label: _(List All Places)

--- a/src/project/gzip_middleware.py
+++ b/src/project/gzip_middleware.py
@@ -1,13 +1,7 @@
 from gzip import GzipFile
 from wsgiref.headers import Headers
 import re
-
-try:
-    # Python 2
-    from cStringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import BytesIO
 
 
 # Precompile the regex to check for gzip headers
@@ -19,7 +13,7 @@ cc_delim_re = re.compile(r'\s*,\s*')
 
 def gzip_buffer(string, compression_level=6):
     """gzips a string."""
-    zbuf = StringIO()
+    zbuf = BytesIO()
     f = GzipFile(filename=None, mode='wb',
             compresslevel=compression_level, fileobj=zbuf)
     f.write(string)
@@ -72,7 +66,7 @@ class GzipMiddleware(object):
 
         # Now get the raw response from the WSGI app
         app_response = {}
-        raw_response = ''.join(self.app(environ,
+        raw_response = b''.join(self.app(environ,
             collect_response(app_response)))
 
         def pass_through(app_response, raw_response):

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -343,7 +343,8 @@ LOCAL_SETTINGS_FILE = os.path.join(os.path.dirname(__file__), 'local_settings.py
 if os.path.exists(LOCAL_SETTINGS_FILE):
     # By doing this instead of import, local_settings.py can refer to
     # local variables from settings.py without circular imports.
-    execfile(LOCAL_SETTINGS_FILE)
+    with open(LOCAL_SETTINGS_FILE) as settingsfile:
+        exec(settingsfile.read())
 
 
 ##############################################################################

--- a/src/sa_web/config.py
+++ b/src/sa_web/config.py
@@ -1,6 +1,9 @@
 import yaml
 import os.path
-import urllib2
+try:
+    from urllib2 import urlopen
+except:
+    from urllib.request import urlopen
 from contextlib import closing
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -27,7 +30,7 @@ def translate(data):
                 for item in data]
 
     # If it's a string, output it, unless it should be excluded
-    elif isinstance(data, basestring):
+    elif isinstance(data, str):
         msg = parse_msg(data)
         if msg is not None:
             return _(msg)
@@ -81,7 +84,7 @@ class ShareaboutsRemoteConfig (_ShareaboutsConfig):
 
     def config_file(self):
         config_fileurl = os.path.join(self.url, 'config.yml')
-        return urllib2.urlopen(config_fileurl)
+        return urlopen(config_fileurl)
 
 
 class ShareaboutsLocalConfig (_ShareaboutsConfig):

--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -7,7 +7,6 @@ import os
 import time
 import hashlib
 import httpagentparser
-import urllib2
 from .config import get_shareabouts_config
 from django.shortcuts import render
 from django.conf import settings
@@ -124,7 +123,7 @@ def index(request, place_id=None):
     if 'user_token' not in request.session:
         t = int(time.time() * 1000)
         ip = request.META['REMOTE_ADDR']
-        unique_string = str(t) + str(ip)
+        unique_string = (str(t) + str(ip)).encode()
         session_token = 'session:' + hashlib.md5(unique_string).hexdigest()
         request.session['user_token'] = session_token
         request.session.set_expiry(0)


### PR DESCRIPTION
teamwork makes the dreamwork

(note: BytesIO in gzip_middleware.py is compatible with Python 2.7 which means Shareabouts is now incompatible with Python 2.6 or prior)