### PR TITLE
Remove unused .survey-reply-link CSS.

### DIFF
--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -957,17 +957,6 @@ ol.responses {
 article.response footer {
   text-align: right;
 }
-.survey-reply-link {
-  color: #999;
-  background: #eee;
-  padding: 0.5em 0.75em;
-  text-decoration: none;
-  font-weight: bold;
-}
-.survey-reply-link:hover {
-  background: #607890;
-  color: #fff;
-}
 
 .submit-btn {
   float: left;


### PR DESCRIPTION
The .survey-reply-link CSS is not used in the application. Confirmed by grepping the source for `survey-reply-link` and `survey-reply`. There is a `reply-link` but that has its own CSS.

See #128.