### PR TITLE
Pin PyYAML<6.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-proxy>=1.2.1
 httpagentparser
 
 # Config
-pyyaml
+pyyaml<6.0
 django-extensions==2.1.0
 
 # Testing


### PR DESCRIPTION
Shareabouts fails with the below traceback when run with the recently released PyYAML 6.0. This change pins PyYAML to a compatible version.

```
Traceback (most recent call last):
  File "[...]/env/lib/python3.6/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "[...]/env/lib/python3.6/site-packages/django/utils/decorators.py", line 110, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "[...]/code/src/sa_web/views.py", line 98, in index
    config.update(settings.SHAREABOUTS.get('CONTEXT', {}))
  File "[...]/code/src/sa_web/config.py", line 75, in update
    self.data.update(other)
  File "[...]/code/src/sa_web/config.py", line 59, in data
    self._yml = yaml.load(config_yml)
TypeError: load() missing 1 required positional argument: 'Loader'
```