### PR TITLE
Upgrade Mapbox GL JS to 1.4.1 to support satellite layers

### DIFF
--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -144,8 +144,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/perliedman-leaflet-control-geocoder/1.6.0/Control.Geocoder.js"></script>
 
   {% if settings.MAPBOX_TOKEN %}
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css" rel='stylesheet' />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.js"></script>
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.css" rel='stylesheet' />
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.js"></script>
   <script src="https://unpkg.com/mapbox-gl-leaflet@0.0.4/leaflet-mapbox-gl.js"></script>
   {% endif %}
 


### PR DESCRIPTION
Currently using a Mapbox layer with `type: mapbox` and a tile-based styles such as satellite imagery fails with the following error (Firefox):

```
Unknown expression "image". If you wanted a literal array, use ["literal", [...]].
````

Support for the `image` expression was added to Mapbox GL JS in version 1.4, so I've conservatively upgraded from 0.53.0 to the latest 1.4 patch release.

While using a normal `url:` config is an alternative, we've found that Mapbox's satellite styles can't be zoomed past 17 or 18 and I believe that the tile-based layers are billed at a higher rate.