### PR TITLE
Upgrade raven package to avoid SyntaxError on Python > 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ mock
 mock_django
 responses==0.2.2
 django-debug-toolbar==1.2.1
-raven==5.19.0  # For Sentry error logging
+raven==6.10.0  # For Sentry error logging
 
 
 # - - - - - - - - - - - - - - - -


### PR DESCRIPTION
The issue here is that "async" became a reserved word in Python 3.7. See https://docs.python.org/3.7/whatsnew/3.7.html.

This is the Raven-specific half of @JohnBrooking's changes from issue #207 and pull request #208.