### PR TITLE
Remove unsupported browser overlay

### DIFF
--- a/src/conf/locale/en/LC_MESSAGES/django.po
+++ b/src/conf/locale/en/LC_MESSAGES/django.po
@@ -162,17 +162,6 @@ msgstr ""
 msgid "Most {{ survey_label_plural }}"
 msgstr ""
 
-#: jstemplates/unsupported-overlay.html:1
-msgid "Proceed Anyway"
-msgstr ""
-
-#: jstemplates/unsupported-overlay.html:2
-msgid ""
-"You are using an unsupported browser. Please\n"
-"    <a href=\"http://browsehappy.com/\">upgrade your browser</a> to improve\n"
-"    your experience."
-msgstr ""
-
 #: templates/base.html:104
 #, python-format
 msgid ""

--- a/src/conf/locale/es/LC_MESSAGES/django.po
+++ b/src/conf/locale/es/LC_MESSAGES/django.po
@@ -104,17 +104,6 @@ msgstr "Lo más {{ support_label_plural }}"
 msgid "Most {{ survey_label_plural }}"
 msgstr "Lo más {{ survey_label_plural }}"
 
-#: jstemplates/unsupported-overlay.html:1
-msgid "Proceed Anyway"
-msgstr "Proceder de todas maneras"
-
-#: jstemplates/unsupported-overlay.html:2
-msgid ""
-"You are using an unsupported browser. Please\n"
-"    <a href=\"http://browsehappy.com/\">upgrade your browser</a> to improve\n"
-"    your experience."
-msgstr "Estás utilizando un navegador no permitido. Por favor\n<a href=\"http://browsehappy.com/\">actualiza tu navegador</a> para mejorar\ntu experiencia."
-
 #: templates/base.html:104
 #, python-format
 msgid ""

--- a/src/sa_web/jstemplates/unsupported-overlay.html
+++ b/src/sa_web/jstemplates/unsupported-overlay.html
@@ -1,7 +1,0 @@
-<div class="unsupported-message">
-  <p class="browsehappy">{{#_}}You are using an unsupported browser. Please
-    <a href="http://browsehappy.com/">upgrade your browser</a> to improve
-    your experience.{{/_}}
-  </p>
-  <a href="#" class="close-btn btn-block close-unsupported-overlay">{{#_}}Proceed Anyway{{/_}}</a>
-</div>

--- a/src/sa_web/static/css/default.css
+++ b/src/sa_web/static/css/default.css
@@ -1241,41 +1241,6 @@ a.shareabouts-logo:hover {
 }
 
 
-/* =Unsupported Browsers
--------------------------------------------------------------- */
-
-.unsupported-overlay {
-  position: relative;
-  z-index: 999999;
-  color: #eee;
-  font-weight: bold;
-}
-.unsupported-message {
-  background-color: #cd2c67;
-  padding: 1em 1em 2em;
-  box-shadow: 0 0.325em 0 rgba(0,0,0,0.1), inset 0 0.325em 0 rgba(0,0,0,0.1);
-}
-.unsupported-message p {
-  font-size: 1.25em;
-  margin-bottom: 0.75em;
-}
-.unsupported-message a {
-  color: #fff;
-}
-a.close-unsupported-overlay {
-  color: #ff5e99;
-  font-size: 1em;
-  float: none;
-  position: relative;
-  top: 0;
-  left: 0;
-  border-radius: 0.325em;
-  text-align: center;
-  text-transform: uppercase;
-  box-shadow: -0.325em 0.325em 0 rgba(0,0,0,0.1);
-}
-
-
 /* =Media Queries for Responsive Layout
 -------------------------------------------------------------- */
 
@@ -1499,20 +1464,6 @@ a.close-unsupported-overlay {
   }
   a.close-btn span {
     display: none;
-  }
-
-  .unsupported-overlay {
-    position: absolute;
-    top: 5em;
-    right: 1em;
-    left: 1em;
-  }
-  .unsupported-message {
-    border-radius: 0 0 0.625em 0.625em;
-  }
-  a.close-unsupported-overlay {
-    right: auto;
-    border-radius: 0.325em;
   }
 
   #content > article {

--- a/src/sa_web/static/js/utils.js
+++ b/src/sa_web/static/js/utils.js
@@ -72,37 +72,6 @@ var Shareabouts = Shareabouts || {};
       }
     },
 
-    isSupported: function(userAgent) {
-      // Mobile Safari UIWebViews may not register as a recognized user agent,
-      // so just assume that browsers that we understand are new and should be
-      // supported.
-      var recognized = (userAgent &&
-                        userAgent.browser &&
-                        userAgent.browser.name &&
-                        userAgent.browser.version);
-      if (!recognized) {
-        return true;
-      }
-
-      switch (userAgent.browser.name) {
-        case 'Chrome':
-        case 'Firefox':
-        case 'Safari':
-        case 'ChromeiOS':
-        case 'MSEdge':
-          return true;
-        case 'Microsoft Internet Explorer':
-          var firstDot = userAgent.browser.version.indexOf('.'),
-              major = parseInt(userAgent.browser.version.substr(0, firstDot), 10);
-
-          if (major > 7) {
-            return true;
-          }
-      }
-
-      return false;
-    },
-
     // NOTE this is not in Shareabouts.js
     // this will be "mobile" or "desktop", as defined in default.css
     getPageLayout: function() {

--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -89,8 +89,6 @@
 
   </header>
 
-  <div class="unsupported-overlay"></div>
-
   <div role="main" id="main">
     <noscript>
       <div class="noscript">
@@ -181,30 +179,6 @@
 
   <script>
     moment.locale('{{LANGUAGE_CODE}}');
-
-    $(function() {
-      // Check official browser support.
-      var userAgent = {{ user_agent_json|safe }};
-
-      if (!Shareabouts.Util.isSupported(userAgent)) {
-        var userAgentData = userAgent,
-            $unsupportedEl = $('.unsupported-overlay'),
-            unsupportedHtml;
-
-        userAgentData['is_ie'] = (userAgent.browser.name === 'Microsoft Internet Explorer');
-        unsupportedHtml = Handlebars.templates['unsupported-overlay'](userAgentData);
-
-        $unsupportedEl.hide()
-        $unsupportedEl.html(unsupportedHtml);
-        $unsupportedEl.slideDown();
-
-        $unsupportedEl.find('.close-btn').click(function(evt) {
-          evt.preventDefault();
-          $unsupportedEl.slideUp();
-          return false;
-        })
-      }
-    });
   </script>
 
   <!-- Bootstrap site and user information -->


### PR DESCRIPTION
Incompatibility with older browsers is no longer a significant issue given the maturity of Shareabouts, and the user-agent detection approach is causing false positives with newer browsers like Edge.