### PR TITLE
Add django-redis dependency and upgrade to support Django 3.2

### DIFF
--- a/app-requirements.txt
+++ b/app-requirements.txt
@@ -6,6 +6,7 @@ django-storages==1.1.8
 python-dateutil==2.8.2
 boto==2.27.0
 raven==6.10.0  # For Sentry error logging
+django-redis==5.3.0
 
 # Templates
 django-jstemplate>=1.3.9

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -239,31 +239,16 @@ if 'DATABASE_URL' in env:
     if USE_GEODB:
         DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 
-if 'REDIS_URL' in env or 'REDISCLOUD_URL' in env:
-    redis_url = env.get('REDIS_URL') or env.get('REDISCLOUD_URL')
-    scheme, connstring = redis_url.split('://')
-    if '@' in connstring:
-        userpass, netloc = connstring.split('@')
-        userename, password = userpass.split(':')
-    else:
-        userpass = None
-        netloc = connstring
+if 'REDIS_URL' in env:
     CACHES = {
-        "default": {
-            "BACKEND": "redis_cache.cache.RedisCache",
-            "LOCATION": "%s:0" % (netloc,),
-            "OPTIONS": {
-                "CLIENT_CLASS": "redis_cache.client.DefaultClient",
-                "PASSWORD": password,
-            } if userpass else {}
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': env.get('REDIS_URL'),
         }
     }
 
     # Django sessions
-    SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
-    # Celery broker
-    BROKER_URL = redis_url.strip('/') + '/1'
+    SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 SHAREABOUTS = {}
 if 'SHAREABOUTS_FLAVOR' in env:
@@ -409,7 +394,6 @@ if SHAREABOUTS['DATASET_ROOT'].startswith('/'):
         'raven.contrib.django.raven_compat',
         'django_ace',
         'django_object_actions',
-        'djcelery',
 
         # OAuth
         'provider',
@@ -450,11 +434,3 @@ if SHAREABOUTS['DATASET_ROOT'].startswith('/'):
     SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,bio'}
 
     SOCIAL_AUTH_LOGIN_ERROR_URL = 'remote-social-login-error'
-
-
-    ###############################################################################
-    #
-    # Background task processing
-    #
-
-    CELERY_RESULT_BACKEND='djcelery.backends.database:DatabaseBackend'


### PR DESCRIPTION
Given that Redis config appears in the default settings, it seems appropriate to include it as a dependency.

The default Redis config in `settings.py` also isn't compatible with a django-redis that supports Django 3.2, so I've simplified the config. My thinking is that the defaults should be simple and more complex needs could be addressed in `local_settings.py`.

I've also removed the Celery config since it's not used by the frontend.