### PR TITLE
Upgrade Grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "scripts": {
     "postinstall": "./node_modules/grunt-cli/bin/grunt"
   },
-  "dependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-concat": "^0.5.0",
-    "grunt-contrib-copy": "^0.7.0",
-    "grunt-contrib-uglify": "^0.6.0",
-    "grunt-contrib-watch": "^0.6.1"
+  "devDependencies": {
+    "grunt": "^1.6.1",
+    "grunt-cli": "^1.4.3",
+    "grunt-contrib-concat": "^2.1.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-uglify": "^5.2.2",
+    "grunt-contrib-watch": "^1.1.0"
   }
 }


### PR DESCRIPTION
Tested successfully on Node.js 18.16.0.

Also moved to `devDepedencies` to indicate that Grunt is only required for the build, not for the app itself.