### PR TITLE
Remove conditional loading of Mapbox GL on MAPBOX_TOKEN

### DIFF
--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -140,7 +140,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.4/leaflet.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/perliedman-leaflet-control-geocoder/1.13.0/Control.Geocoder.js"></script>
 
-  {% if settings.MAPBOX_TOKEN %}
+  {% if uses_mapbox_layers %}
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.css" rel='stylesheet' />
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.4.1/mapbox-gl.js"></script>
   <script src="https://unpkg.com/mapbox-gl-leaflet@0.0.4/leaflet-mapbox-gl.js"></script>

--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -200,6 +200,11 @@ def index(request, place_id=None):
         if place:
             place = json.loads(place)
 
+    try:
+        uses_mapbox_layers = 'mapbox' in {layer['type'] for layer in config['map']['layers']}
+    except KeyError:
+        uses_mapbox_layers = False
+
     context = {'config': config,
 
                'user_token_json': user_token_json,
@@ -213,6 +218,7 @@ def index(request, place_id=None):
 
                'api_user': api.current_user(default=None),
                'api_sessionid': api.sessionid,
+               'uses_mapbox_layers': uses_mapbox_layers,
                }
 
     return render(request, 'index.html', context)


### PR DESCRIPTION
MAPBOX_TOKEN is only used for geocoding, not displaying maps, so there's no reason to use it to conditionally load Mapbox GL. It's also confusing when your map doesn't show up because there's no MAPBOX_TOKEN in the Django settings.