### PR TITLE
Remove syntax for Python < 3.6

### DIFF
--- a/src/project/backends.py
+++ b/src/project/backends.py
@@ -7,11 +7,11 @@ class CachedS3BotoStorage(S3BotoStorage):
     Django compressor, which must have local access to static files.
     """
     def __init__(self, *args, **kwargs):
-        super(CachedS3BotoStorage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.local_storage = get_storage_class(
             "compressor.storage.CompressorFileStorage")()
 
     def save(self, name, content):
-        name = super(CachedS3BotoStorage, self).save(name, content)
+        name = super().save(name, content)
         self.local_storage._save(name, content)
         return name

--- a/src/project/gzip_middleware.py
+++ b/src/project/gzip_middleware.py
@@ -36,13 +36,13 @@ def patch_vary_headers(headers, new_values):
     else:
         vary_headers = []
 
-    existing_values = set([header.lower() for header in vary_headers])
+    existing_values = {header.lower() for header in vary_headers}
     additional_values = [new_value for new_value in new_values
                          if new_value.lower() not in existing_values]
     headers['Vary'] = ', '.join(vary_headers + additional_values)
 
 
-class GzipMiddleware(object):
+class GzipMiddleware:
     """The actual WSGI middleware to wrap around your app and gzip all output.
     This automatically adds the required HTTP headers.
     """

--- a/src/project/twinkie.py
+++ b/src/project/twinkie.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.conf import settings
 from wsgiref.headers import Headers
 from wsgiref.handlers import format_date_time
@@ -15,7 +13,7 @@ log = getLogger(__name__)
 # log.addHandler(StreamHandler(stderr))
 
 
-class ExpiresMiddleware (object):
+class ExpiresMiddleware:
     """WSGI middleware that intercepts calls to the static files
     directory, as defined by the STATIC_URL setting, and serves those files.
     """

--- a/src/sa_web/config.py
+++ b/src/sa_web/config.py
@@ -62,7 +62,7 @@ def translate(data):
     # If it's an object, recurse
     if isinstance(data, dict):
         return {k: translate(v)
-                     for k, v in data.items()}
+                for k, v in data.items()}
 
     # If it's a list, recurse on each item
     elif isinstance(data, list):

--- a/src/sa_web/config.py
+++ b/src/sa_web/config.py
@@ -61,8 +61,8 @@ def translate(data):
 
     # If it's an object, recurse
     if isinstance(data, dict):
-        return dict([(k, translate(v))
-                     for k, v in data.items()])
+        return {k: translate(v)
+                     for k, v in data.items()}
 
     # If it's a list, recurse on each item
     elif isinstance(data, list):
@@ -86,7 +86,7 @@ def parse_msg(s):
         return s[2:-1]
 
 
-class _ShareaboutsConfig (object):
+class _ShareaboutsConfig:
     """
     Base class representing Shareabouts configuration options
     """

--- a/src/sa_web/management/commands/flavormessages.py
+++ b/src/sa_web/management/commands/flavormessages.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from django.core.management import call_command
 from django.core.management.commands.makemessages import Command as MakeMessagesCommand
 import os

--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -66,7 +66,7 @@ class ShareaboutsApiError (Exception):
         self.errors = errors
 
 
-class ShareaboutsApi (object):
+class ShareaboutsApi:
     def __init__(self, dataset_root, sessionid=None):
         self.dataset_root = dataset_root
         self.auth_root = make_auth_root(dataset_root)
@@ -80,7 +80,7 @@ class ShareaboutsApi (object):
         self.update_sessionid()
         return (res.text if res.status_code == 200 else default)
 
-    def current_user(self, default=u'null', **kwargs):
+    def current_user(self, default='null', **kwargs):
         uri = make_resource_uri('current', root=self.auth_root)
         res = self.session.get(uri, **kwargs)
         self.update_sessionid()


### PR DESCRIPTION
This change removes some remaining Python 2 and Python < 3.6 syntax. These changes were applied with `pyupgrade --py36-plus`.