### PR TITLE
Switch to Django 2.0-style path() URLconfs

### DIFF
--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -1,36 +1,17 @@
-from django.conf.urls import include, url
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.urls import include, path
+from django.conf import settings
 from django.contrib import admin
 from django.views.i18n import set_language
 
 admin.autodiscover()
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-# admin.autodiscover()
-
-# By default, static assets will be served from Django.  It is recommended that
-# you use a better suited server instead.  Consult the documentation on serving
-# static files with Django for your deploy platform.
-
-urlpatterns = staticfiles_urlpatterns() + [
-    # Examples:
-    # url(r'^$', 'project.views.home', name='home'),
-    # url(r'^project/', include('project.foo.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
-
-    url(r'^admin/', admin.site.urls),
-    url(r'^choose-language$', set_language, name='set_language'),
-    url(r'^', include('sa_web.urls')),
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('choose-language', set_language, name='set_language'),
+    path('', include('sa_web.urls')),
 ]
 
-from django.conf import settings
 if settings.SHAREABOUTS['DATASET_ROOT'].startswith('/'):
     urlpatterns = [
-        url(r'^full-api/', include('sa_api_v2.urls')),
+        path('full-api/', include('sa_api_v2.urls')),
     ] + urlpatterns

--- a/src/sa_web/urls.py
+++ b/src/sa_web/urls.py
@@ -1,26 +1,13 @@
-from django.conf.urls import url
+from django.urls import path, re_path
+
 from . import views
 from sa_login import views as login_views
 
-# Uncomment the next two lines to enable the admin:
-# from django.contrib import admin
-# admin.autodiscover()
-
 urlpatterns = [
-    # Examples:
-    # url(r'^$', 'project.views.home', name='home'),
-    # url(r'^project/', include('project.foo.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
-    # url(r'^admin/', include(admin.site.urls)),
-
-    url(r'^api/(.*)$', views.api, name='api_proxy'),
-    url(r'^users/(.*)$', views.users, name='auth_proxy'),
-    url(r'^download/(.*).csv$', views.csv_download, name='csv_proxy'),
-    url(r'^place/(?P<place_id>[^/]+)$', views.index, name='place'),
-    url(r'^login/$', login_views.login, name='login'),
-    url(r'^', views.index, name='index'),
+    path('api/<path>', views.api, name='api_proxy'),
+    path('users/<path>', views.users, name='auth_proxy'),
+    path('download/<path>.csv', views.csv_download, name='csv_proxy'),
+    path('place/<place_id>', views.index, name='place'),
+    path('login/', login_views.login, name='login'),
+    re_path(r'^', views.index, name='index'),
 ]


### PR DESCRIPTION
Fixes RemovedInDjango40Warning.

Removed the commented out examples from the Django default template, since these aren't really relevant.

Also removed `staticfiles_urlpatterns` as these are provided automatically by Django in development and are disabled in production.
