### PR TITLE
Correct the Django 2.0-style URLconf changes

### DIFF
--- a/src/sa_web/urls.py
+++ b/src/sa_web/urls.py
@@ -4,9 +4,9 @@ from . import views
 from sa_login import views as login_views
 
 urlpatterns = [
-    path('api/<path>', views.api, name='api_proxy'),
-    path('users/<path>', views.users, name='auth_proxy'),
-    path('download/<path>.csv', views.csv_download, name='csv_proxy'),
+    re_path(r'^api/(.*)$', views.api, name='api_proxy'),
+    re_path(r'^users/(.*)$', views.users, name='auth_proxy'),
+    re_path('^download/(.*)$.csv', views.csv_download, name='csv_proxy'),
     path('place/<place_id>', views.index, name='place'),
     path('login/', login_views.login, name='login'),
     re_path(r'^', views.index, name='index'),


### PR DESCRIPTION
Previous changes cause comment form submissions to fail as paths can include forward-slashes. Fixed now.