### PR TITLE
Upgrade gunicorn

### DIFF
--- a/app-requirements.txt
+++ b/app-requirements.txt
@@ -1,6 +1,6 @@
 # The server
 django>3.2,<4
-gunicorn==19.7.1
+gunicorn>=20.0.0
 dj-static==0.0.6
 django-storages==1.1.8
 python-dateutil==2.8.2


### PR DESCRIPTION
This avoids "ModuleNotFoundError: No module named 'gunicorn.six.moves'" as seen with gunicorn 19 on Ubuntu 24.04.