### PR TITLE
Fix checkboxgroup value filtering in the admin to work with arrays of selected values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Copy the following template when creating a new version entry:
 Development (master)
 -----------------------------
   * Bug Fixes:
-    - ...
+    - Fix checkboxgroup value filtering in the admin to work with arrays of selected values
 
   * New Features:
     - ...

--- a/src/sa_admin/static/sa_admin/js/places_filter.js
+++ b/src/sa_admin/static/sa_admin/js/places_filter.js
@@ -158,7 +158,11 @@ class PlacesChoiceFilter extends PlacesFilter {
     if (filterValues.length === 0) { return true; }
 
     const attrValue = place.get(this.column.attr);
-    return filterValues.includes(attrValue);
+    if (Array.isArray(attrValue)) {
+      return attrValue.some(value => filterValues.includes(value));
+    } else {
+      return filterValues.includes(attrValue);
+    }
   }
 
   clear() {


### PR DESCRIPTION
Support multiple selected checkbox values in `PlacesChoiceFilter` filter predicate.