### PR TITLE
fix: Include non-visible data in admin requests (but avoid patching the PlaceCollection url)

### DIFF
--- a/src/sa_admin/templates/sa_admin/base.html
+++ b/src/sa_admin/templates/sa_admin/base.html
@@ -78,8 +78,6 @@
         staticUrl: {{ STATIC_URL | as_json | safe }},
         mapboxToken: {{ settings.MAPBOX_TOKEN | as_json | safe }},
       };
-
-      Shareabouts.PlaceCollection.prototype.url += '?include_private&include_invisible';
     </script>
     {% endblock %}
 </html>

--- a/src/sa_admin/templates/sa_admin/dashboard.html
+++ b/src/sa_admin/templates/sa_admin/dashboard.html
@@ -63,7 +63,8 @@
       pageSuccess: onPlacesPageSuccess,
       pageError: onPlacesPageError,
       data: {
-        include_private: true
+        include_private: true,
+        include_invisible: true,
       },
     });
   </script>

--- a/src/sa_admin/templates/sa_admin/place_detail.html
+++ b/src/sa_admin/templates/sa_admin/place_detail.html
@@ -40,7 +40,8 @@
       success: onPlaceSuccess,
       error: onPlaceError,
       data: {
-        include_private: true
+        include_private: true,
+        include_invisible: true,
       },
     });
   </script>


### PR DESCRIPTION
Place detail pages were showing as blank in the admin because of incorrectly specified URLs (e.g. `/api/places?include_private&include_invisible/67584`). This is because I was patching the `PlaceCollection` URL to include these flags.

Instead, the flags can and should be specified when the `fetch` happens.