### PR TITLE
Update the Google Analytics integration to use the more recent gtag API

### DIFF
--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -256,7 +256,14 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
-    gtag('config', '{{ settings.GOOGLE_ANALYTICS_ID }}', { 'cookieFlags': 'SameSite=None; Secure' });
+    gtag('config', '{{ settings.GOOGLE_ANALYTICS_ID }}', { 
+      'cookie_flags': 'SameSite=None; Secure',
+      'send_page_view': false,
+    });
+    gtag('event', 'page_view', {
+      page_title: document.title,
+      page_location: window.location.pathname,
+    });
   </script>
   {% endif %}
 


### PR DESCRIPTION
This change updates the behavior of the `route`, `user` and `app` logging events to be compatible with the semantics of the gtag interface to Google Analytics.